### PR TITLE
Refactor fees-fx calculation into reusable function

### DIFF
--- a/services/fees-fx/go.mod
+++ b/services/fees-fx/go.mod
@@ -1,0 +1,5 @@
+module cs2arb/feesfx
+
+go 1.22
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/services/fees-fx/go.sum
+++ b/services/fees-fx/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/services/fees-fx/main_test.go
+++ b/services/fees-fx/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+func TestComputeNetSpread(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  NetSpreadParams
+		netBuy  float64
+		netSell float64
+		spread  float64
+	}{
+		{
+			name: "no fees",
+			params: NetSpreadParams{
+				BuyPrice:  100,
+				SellPrice: 110,
+				FXRate:    1,
+			},
+			netBuy:  100,
+			netSell: 110,
+			spread:  1000,
+		},
+		{
+			name: "with fees",
+			params: NetSpreadParams{
+				BuyPrice:  100,
+				SellPrice: 110,
+				BuyFee:    MarketFee{BuyBps: 10, Fixed: 1},
+				SellFee:   MarketFee{SellBps: 20, Fixed: 2},
+				FXRate:    1,
+			},
+			netBuy:  101.1,
+			netSell: 107.78,
+			spread:  660.7319485657771,
+		},
+		{
+			name: "fx conversion",
+			params: NetSpreadParams{
+				BuyPrice:  100,
+				SellPrice: 100,
+				BuyFee:    MarketFee{BuyBps: 100, Fixed: 1},
+				SellFee:   MarketFee{SellBps: 50, Fixed: 2},
+				FXRate:    1.1,
+			},
+			netBuy:  102,
+			netSell: 107.45,
+			spread:  534.3137254901977,
+		},
+	}
+
+	const eps = 1e-6
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nb, ns, sp := computeNetSpread(tt.params)
+			if math.Abs(nb-tt.netBuy) > eps {
+				t.Fatalf("net buy got %f want %f", nb, tt.netBuy)
+			}
+			if math.Abs(ns-tt.netSell) > eps {
+				t.Fatalf("net sell got %f want %f", ns, tt.netSell)
+			}
+			if math.Abs(sp-tt.spread) > eps {
+				t.Fatalf("spread got %f want %f", sp, tt.spread)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- encapsulate net spread calculation in `computeNetSpread`
- add `NetSpreadParams` for prices, fees and FX rate
- cover various fee and FX scenarios with unit tests

## Testing
- `go test ./...` in `services/fees-fx`


------
https://chatgpt.com/codex/tasks/task_b_68b6dfd741f4832f964014734d917e2f